### PR TITLE
Add stateless reset support

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -357,6 +357,7 @@ Triggers:
 * "error" // when closing because of an unexpected event
 * "clean" // when closing normally
 * "application" // e.g., HTTP/3's GOAWAY frame
+* "stateless_reset" // because a stateless reset was received
 
 ### MIGRATION-related events
 e.g., path_updated
@@ -501,6 +502,8 @@ Data:
 
     is_coalesced?:boolean,
 
+    stateless_reset_token?:string, // only if PacketType === stateless_reset
+
     raw_encrypted?:string, // for debugging purposes
     raw_decrypted?:string  // for debugging purposes,
 
@@ -533,6 +536,8 @@ Data:
     frames?:Array<QuicFrame>, // see appendix for the definitions
 
     is_coalesced?:boolean,
+
+    stateless_reset_token?:string, // only if PacketType === stateless_reset
 
     raw_encrypted?:string, // for debugging purposes
     raw_decrypted?:string  // for debugging purposes,
@@ -1454,6 +1459,7 @@ enum PacketType {
     onertt = "1RTT",
     retry,
     version_negotiation,
+    stateless_reset,
     unknown
 }
 ~~~
@@ -1687,7 +1693,7 @@ class NewConnectionIDFrame{
   length:number;
   connection_id:string;
 
-  reset_token:string;
+  stateless_reset_token:string;
 }
 ~~~
 


### PR DESCRIPTION
Partially fixes #64.

Main change is adding `stateless_reset` as a PacketType.

The `stateless_reset_token` is added as a field to packet_sent and packet_received.
Any of the "unpredictable bits" can be logged as `raw_encrypted`

Added a trigger to `connection_state_update` to indicate if a connection goes into draining/closing because a valid stateless_reset was received.

Backwards compatibility break: renamed `reset_token` to `stateless_reset_token` on the NewConnectionID frame definition (for consistency). 

Been thinking about a way to signal an "invalid" stateless reset, but figured there is no way to distinguish it from an otherwise garbage datagram, so decided it was impossible. Not 100% sure about the "looping case" where you continually lower the packet size. Maybe that's solved by adding a generic "packet_size" trigger value to `packet_dropped` though?