### PR TITLE
Merge loss_timer events

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -817,8 +817,6 @@ Data:
 
     ssthresh?:number, // in bytes
 
-    packet_number_space?:PacketNumberSpace, // mainly necessary if an implementation does not log other events (e.g., key_retired) that indicate the pn-space has changed
-
     // qlog defined
     packets_in_flight?:number, // sum of all packet number spaces
     in_recovery?:boolean, // high-level signal. For more granularity, see congestion_state_updated
@@ -898,10 +896,6 @@ TODO: how about CC algo's that use multiple timers? How generic do these events
 need to be? Just support QUIC-style recovery from the spec or broader?
 
 TODO: read up on the loss detection logic in draft-27+ and see if this suffices
-
-Triggers:
-
-* no_packets_outstanding // for cancelling the timer
 
 ### packet_lost
 Importance: Core


### PR DESCRIPTION
Fixes #69.

Not 100% sure this is enough for all the latest draft-27(+) changes though, added a TODO in the draft for that purpose. 

Also added a packet_number_space field to metrics_updated to be flexible for implementations that don't want to implement all types of events. It's not a great fit at that location, but it seemed the most synergistic without having a completely new event type.

PTAL @marten-seemann 