### PR TITLE
add a packet_dropped trigger for duplicate packets

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -589,6 +589,7 @@ Triggers:
 * "unexpected_packet"
 * "unexpected_source_connection_id"
 * "unexpected_version"
+* "duplicate"
 
 Note: sometimes packets are dropped before they can be associated with a
 particular connection (e.g., in case of "unsupported_version"). This situation is


### PR DESCRIPTION
See https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#name-packet-numbers.