### PR TITLE
remove the UnknownFrame QUIC frame type

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -1769,17 +1769,6 @@ class HandshakeDoneFrame{
 }
 ~~~
 
-### UnknownFrame
-
-~~~
-class UnknownFrame{
-    frame_type:string = "unknown";
-    raw_frame_type:number;
-
-    raw?:string; // hex encoded
-}
-~~~
-
 ### TransportError
 
 ~~~


### PR DESCRIPTION
Other than H3 frames, QUIC frames are not TLV encoded. It's therefore not possible to parse a frame type that your implementation doesn't understand. In fact, it's a protocol violation to even send such a frame.