### PR TITLE
add an "invalid_initial" trigger to the packet_dropped event

### DIFF
--- a/draft-marx-qlog-event-definitions-quic-h3.md
+++ b/draft-marx-qlog-event-definitions-quic-h3.md
@@ -589,6 +589,7 @@ Triggers:
 * "unexpected_packet"
 * "unexpected_source_connection_id"
 * "unexpected_version"
+* "invalid_initial"
 
 Note: sometimes packets are dropped before they can be associated with a
 particular connection (e.g., in case of "unsupported_version"). This situation is


### PR DESCRIPTION
There are two conditions an Initial packet has to fulfill:
1. It's DCID must be >= 8 bytes long.
2. The size of the datagram must be >= 1200.

None of the other triggers for the `packet_dropped` event seem appropriate for this.